### PR TITLE
Improve presentation and description.md

### DIFF
--- a/description.md
+++ b/description.md
@@ -71,8 +71,7 @@ As you can see, `your content`  refers to what you wrote, and `other content` re
 `other content` instead of `your content` or you can make a new change. You always need to keep on mind the option you take must satisfy both parts, you and them, and it must make sense.
 
 * Repeat process above with all the conflicts you have.
-* You are now ready to do `add` and `commit` and synchronize your repository again with the upstream, you
-can check the [wiki](https://github.com/UNIZAR-30246-WebEngineering/hello/wiki) to do this task.
+* You are now ready to do `add` and `commit` , synchronize your repository again with the upstream and `push` ,you can check the [wiki](https://github.com/UNIZAR-30246-WebEngineering/hello/wiki) to do this task.
 
 ###Spring Framework Annotations
 You may find some [Spring Java annotations](http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/annotation/package-tree.html) in specific pieces of code. The following annotations are used in this project:

--- a/description.md
+++ b/description.md
@@ -67,11 +67,11 @@ If you are not able to merge your improvements on the code with your updated res
      
      \>>>>>upstream/master
  
-As you can see, `your content`  refers to what you wrote, and `other content` refers to what other people wrote. Here you have a few options; you can keep your changes by deleting `other content` ,you can use
-`other content` instead of `your content` or you can make a new change. You always need to keep on mind the option you take must satisfy both parts, you and them, and it must make sense.
+As you can see, `your content`  refers to what you wrote, and `other content` refers to what other people wrote, the rest added are conflict markers. Here you have a few options; you can keep your changes by
+deleting `other content` , you can use `other content` instead of `your content` or you can make a new change. You always need to keep on mind the option you take must satisfy both parts, you and them, and it must make sense. Then you can delete the conflict markers.
 
 * Repeat process above with all the conflicts you have.
-* You are now ready to do `add` and `commit` , synchronize your repository again with the upstream and `push` ,you can check the [wiki](https://github.com/UNIZAR-30246-WebEngineering/hello/wiki) to do this task.
+* You are now ready to do `add` and `commit` , synchronize your repository again with the upstream, and `push` , you can check the [wiki](https://github.com/UNIZAR-30246-WebEngineering/hello/wiki) to do this task.
 
 ###Spring Framework Annotations
 You may find some [Spring Java annotations](http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/annotation/package-tree.html) in specific pieces of code. The following annotations are used in this project:

--- a/description.md
+++ b/description.md
@@ -52,7 +52,27 @@ Testing your code is very easy.
 The later command will compile normal and tests classes in your project. Then test classes will be executed and tested.
 Error message will appear in the screen if something has gone wrong.
 	
-	
+###Conflicts on merge process?
+If you are not able to merge your improvements on the code with your updated respository, don't panic  and stop typing random commands, this may help you.  Once you have added and committed your local files you will have to synchronize your forked repository  with your upstream repository and here is where you might find conflicts in some of the files. Solving  this issues is easy:
+
+* Identifying the conflict:
+  * When there is a conflict, you will see on the console where it is (There may be more than one).
+* Now you need to open the file in conflict with any text editor and you will see that some words have appeared in this file and it will have the next format:
+
+     any content  
+     <<<<< HEAD  
+     your content  
+     =====  
+     other content
+     
+     \>>>>>upstream/master
+ 
+As you can see, `your content`  refers to what you wrote, and `other content` refers to what other people wrote. Here you have a few options; you can keep your changes by deleting `other content` ,you can use
+`other content` instead of `your content` or you can make a new change. You always need to keep on mind the option you take must satisfy both parts, you and them, and it must make sense.
+
+* Repeat process above with all the conflicts you have.
+* You are now ready to do `add` and `commit` and synchronize your repository again with the upstream, you
+can check the [wiki](https://github.com/UNIZAR-30246-WebEngineering/hello/wiki) to do this task.
 
 ###Spring Framework Annotations
 You may find some [Spring Java annotations](http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/annotation/package-tree.html) in specific pieces of code. The following annotations are used in this project:
@@ -129,3 +149,12 @@ It allows to those third-party services to easily know when a change has been ma
 In the case of Github, it allows you to set custom webhooks so, when something happens in your repository (like a pull, push) , an HTTP POST is made to the provided URL. It is very useful for [Continuous Integration](https://en.wikipedia.org/wiki/Continuous_integration) tools, like Travis. To view what webhooks are set-up on your repository, go to Settings -> Webhook & Services.
 
 This is how Travis works. Travis set up a webhook on your repository, so when your code changes, Travis servers receive a request and then, build your updated code. Although Travis works with Github, if they add support for custom webhooks, it would be easy to create your owns (You would have only to make HTTP requests to Travis). 
+
+###Bootstrap
+Bootstrap is a common Framework for HTML, CSS and Javascript used for developing Web Applications. It
+contains templates with formularies, buttons and other kind of design components as well as functionalities to make a responsive application.
+#####Glyphicon Components
+  Bootstrap includes a set of glyphs components that can be used to improve the web's design. They are
+  monochromatic icons and symbols in order to enrich the usability of the web by making the navigation
+  clearer and easier. Theses glyphs are usually not available for free but their creator made them free
+  for Bootstrap. You can find more information going to [Glyphicons](http://glyphicons.com).

--- a/src/main/webapp/WEB-INF/jsp/wellcome.jsp
+++ b/src/main/webapp/WEB-INF/jsp/wellcome.jsp
@@ -11,10 +11,12 @@
 	<script type="text/javascript" src="webjars/jquery/2.1.4/jquery.min.js" ></script>
 
 	<!-- Shows the time and a message (From HelloController)
+	divided on two lines and one message per line, with glyphicons added
+	clearing the source format.
 	Check Glyphicon section on description.md for more information-->
 
-	<span class="glyphicon glyphicon-time" ><kbd>${time}</kbd></span><br>
-	<span class="glyphicon glyphicon-user" ><kbd>${message}</kbd></span>
+	<span class="glyphicon glyphicon-time" ><kbd> ${time}</kbd></span><br>
+	<span class="glyphicon glyphicon-user" ><kbd> ${message}</kbd></span>
 </body>
 
 </html>

--- a/src/main/webapp/WEB-INF/jsp/wellcome.jsp
+++ b/src/main/webapp/WEB-INF/jsp/wellcome.jsp
@@ -10,9 +10,11 @@
 
 	<script type="text/javascript" src="webjars/jquery/2.1.4/jquery.min.js" ></script>
 
-	<!-- Shows the time and a message (From HelloController)-->
+	<!-- Shows the time and a message (From HelloController)
+	Check Glyphicon section on description.md for more information-->
 
-	<kbd>${time}<span class="glyphicon glyphicon-console" ></span>${message}</kbd>
+	<span class="glyphicon glyphicon-time" ><kbd>${time}</kbd></span><br>
+	<span class="glyphicon glyphicon-user" ><kbd>${message}</kbd></span>
 </body>
 
 </html>


### PR DESCRIPTION
With this pull I modify the behaviour of this application by splitting the one-line message with `date` and `message` in two lines and matching each one with a different glyphicon. I have also added more information to description.md about Bootstrap, Glyphicon library and how to solve conflicts when merging.